### PR TITLE
Use mflag instead of flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
+  - 1.6
   - 1.5
   - 1.4
 script:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ deps:
 	go get golang.org/x/tools/cmd/vet
 
 depsdev:
+	go get -u github.com/docker/docker/pkg/mflag
 	go get -u github.com/mattn/go-shellwords
 	go get -u github.com/mitchellh/gox
 	go get -u github.com/tcnksm/ghr

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ default: test
 deps:
 	go get -d -t ./...
 	go get golang.org/x/tools/cmd/cover
-	go get golang.org/x/tools/cmd/vet
 
 depsdev:
 	go get -u github.com/docker/docker/pkg/mflag

--- a/cli_test.go
+++ b/cli_test.go
@@ -26,15 +26,44 @@ func (o NGCommand) run(c []string) int {
 	return 1
 }
 
+func TestNoArguments(t *testing.T) {
+	outStream, errStream = *new(bytes.Buffer), *new(bytes.Buffer)
+	command = OKCommand{}
+
+	cli := &CLI{outStream: &outStream, errStream: &errStream}
+	args := strings.Split("./retry", " ")
+
+	if status := cli.Run(args); status != ExitCodeOK {
+		t.Fatalf("expected %d, got %d.", ExitCodeOK, status)
+	}
+
+	expected := `
+Usage: retry [options]
+
+Options:
+  -c, --count=2        retry count
+  -i, --interval=3s    retry interval
+  -l, --verbose        print verbose log
+  -s, --shell          use shell
+  -v, --version        print version information
+
+Example:
+  $ retry -i 5s -c 2 /usr/lib64/nagios/plugins/check_http -w 10 -c 15 -H localhost
+`
+	if !strings.Contains(errStream.String(), expected) {
+		t.Fatalf("expected %s, got %s.", expected, errStream.String())
+	}
+}
+
 func TestVersion(t *testing.T) {
 	outStream, errStream = *new(bytes.Buffer), *new(bytes.Buffer)
 	command = OKCommand{}
 
 	cli := &CLI{outStream: &outStream, errStream: &errStream}
-	args := strings.Split("./retry -version", " ")
+	args := strings.Split("./retry --version", " ")
 
 	if status := cli.Run(args); status != ExitCodeOK {
-		t.Fatalf("expected %d, got %d.", ExitCodeOK, status)
+		t.Fatalf("expected %d, got %d.", ExitCodeError, status)
 	}
 
 	expected := fmt.Sprintf("retry version %s", Version)
@@ -48,7 +77,7 @@ func TestInterval(t *testing.T) {
 	command = NGCommand{}
 
 	cli := &CLI{outStream: &outStream, errStream: &errStream}
-	args := strings.Split("./retry -interval 5s "+exampleCmd, " ")
+	args := strings.Split("./retry --interval 5s "+exampleCmd, " ")
 
 	start := time.Now()
 	status := cli.Run(args)
@@ -70,7 +99,7 @@ func TestCount(t *testing.T) {
 	command = NGCommand{}
 
 	cli := &CLI{outStream: &outStream, errStream: &errStream}
-	args := strings.Split("./retry -count 1 "+exampleCmd, " ")
+	args := strings.Split("./retry --count 1 "+exampleCmd, " ")
 
 	if status := cli.Run(args); status == ExitCodeOK {
 		t.Fatalf("expected not %d, got %d.", ExitCodeOK, status)
@@ -88,7 +117,7 @@ func TestShell(t *testing.T) {
 
 	cli := &CLI{outStream: &outStream, errStream: &errStream}
 	os.Setenv("SHELL", "/bin/bash")
-	args := strings.Split("./retry -shell "+exampleCmd, " ")
+	args := strings.Split("./retry --shell "+exampleCmd, " ")
 
 	if status := cli.Run(args); status != ExitCodeOK {
 		t.Fatalf("expected %d, got %d", ExitCodeOK, status)

--- a/command.go
+++ b/command.go
@@ -31,7 +31,7 @@ func (r RealCommand) run(c []string) int {
 	if len(c) > 1 {
 		cmd = exec.Command(c[0], c[1:]...)
 	} else {
-		cmd = exec.Command(c[0])
+		return ExitCodeError
 	}
 
 	cmd.Stdout = r.outStream

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@ package main
 const Name string = "retry"
 
 // Version
-const Version string = "0.2.0"
+const Version string = "0.3.0"


### PR DESCRIPTION
### current:

```sh
$ retry --help
Usage of retry:
  -c int
        Retry count(Short) (default 2)
  -count int
        Retry count (default 2)
  -i string
        Retry interval(Short) (default "3s")
  -interval string
        Retry interval (default "3s")
  -shell
        Use shell
  -verbose
        Print verbose log.
  -version
        Print version information and quit.
```

### new:

```sh
$ retry --help

Usage: retry [options]

Options:
  -c, --count=2        retry count
  -i, --interval=3s    retry interval
  -l, --verbose        print verbose log
  -s, --shell          use shell
  -v, --version        print version information

Example:
  $ retry -i 5s -c 2 /usr/lib64/nagios/plugins/check_http -w 10 -c 15 -H localhost
```

Need two hyphens for long option. Fix for runtime error if no arguments. https://github.com/linyows/go-retry/pull/5/commits/20bf2c6e4e4cb72fc5b97432af2baeb923ddb8d5